### PR TITLE
[PUX-183] Default `scheme_id` to `faster_payments`

### DIFF
--- a/src/models/payments/request.ts
+++ b/src/models/payments/request.ts
@@ -30,8 +30,8 @@ export const isPaymentRequest = (obj: any): obj is PaymentRequest => {
 };
 
 export const intoSingleImmediatePaymentRequest = ({
-  scheme_id,
   provider_id,
+  scheme_id = 'faster_payments_service',
   currency = 'GBP',
   amount_in_minor = 1,
   reference = 'Test Payment',


### PR DESCRIPTION
Now getting `Bad Request` from `Payments API` without specifying the `scheme_id`.

```JSON
{"error":"Invalid parameters","details":{"parameters":{"single_immediate_payment.scheme_id":["Value is required"]}}}
```