### PR TITLE
[PUX-521] Implement Proxy to [POST] /v3/payments endpoint

### DIFF
--- a/src/clients/paymentv3-client.ts
+++ b/src/clients/paymentv3-client.ts
@@ -1,0 +1,44 @@
+import axios, { AxiosInstance } from 'axios';
+import AuthenticationClient from './authentication-client';
+import logger from 'middleware/logger';
+import { HttpException } from 'middleware/errors';
+import RetryClientFactory from './retry-client-factory';
+import config from 'config';
+import { CreatePaymentRequest, CreatePaymentRequestReponse } from 'models/v3/payments-api/create_payment';
+import initRetryPolicy from './retry-policy';
+
+export default class PaymentClient {
+  private client: AxiosInstance;
+  private authenticationClient: AuthenticationClient;
+
+  constructor(authenticationClient: AuthenticationClient) {
+    const client = logger.client(
+      'payment',
+      axios.create({
+        timeout: config.HTTP_CLIENT_TIMEOUT,
+        baseURL: config.PAYMENTS_V3_URI,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    this.client = new RetryClientFactory(initRetryPolicy(authenticationClient)).attach(client);
+    this.authenticationClient = authenticationClient;
+  }
+
+  private getHeaders = async () => ({
+    'authorization': await this.authenticationClient.authenticate(),
+    'content-type': 'application/json'
+  });
+
+  initiatePayment = async (request: CreatePaymentRequest) => {
+    const headers = await this.getHeaders();
+
+    try {
+      const { data } = await this.client.post<CreatePaymentRequestReponse>('/payments', request, { headers });
+      return data;
+    } catch (error) {
+      console.log(error);
+      throw HttpException.fromAxiosError(error, 'error_description');
+    }
+  };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,5 +9,6 @@ export default {
   HTTP_CLIENT_TIMEOUT: process.env.HTTP_CLIENT_TIMEOUT ? +process.env.HTTP_CLIENT_TIMEOUT : 10000,
   AUTH_URI: process.env.AUTH_URI || 'https://auth.truelayer-sandbox.com',
   PAYMENTS_URI: process.env.PAYMENTS_URI || 'https://pay-api.truelayer-sandbox.com/v2',
+  PAYMENTS_V3_URI: process.env.PAYMENTS_V3_URI || 'https://test-pay-api.t7r.dev',
   PORT: process.env.PORT || 3000
 };

--- a/src/controllers/paymentsV3.ts
+++ b/src/controllers/paymentsV3.ts
@@ -1,11 +1,50 @@
 import { NextFunction, Request, Response } from 'express';
 
+import { v4 as uuid } from 'uuid';
+import AuthenticationClient from 'clients/authentication-client';
+import PaymentsClient from 'clients/paymentv3-client';
+import { HttpException } from 'middleware/errors';
+import config from 'config';
+import { BeneficiaryType, PaymentMethodType, SchemeIdentifierType } from 'models/v3/payments-api/create_payment';
+
 export default class PaymentsV3Controller {
-  createPayment = async (_req: Request, res: Response, _next: NextFunction) => {
-    res.status(501).send();
+  private paymentClient = new PaymentsClient(new AuthenticationClient());
+
+  createPayment = async (_req: Request, res: Response, next: NextFunction) => {
+    const request = this.buildPaymentRequest();
+
+    try {
+      // Ideally we should use DTOs / Domain Types but givent that the API spec is still work in progress, we keep the type transparent
+      const response = await this.paymentClient.initiatePayment(request);
+      res.status(200).send(response);
+    } catch (e) {
+      next(e instanceof HttpException ? e : new HttpException(500, 'Failed to initiate payment.'));
+    }
   };
 
   getPayment = async (_req: Request, res: Response, _next: NextFunction) => {
     res.status(501).send();
   };
+
+  private buildPaymentRequest() {
+    return {
+      id: uuid(),
+      amount_in_minor: 1,
+      currency: 'GBP',
+      payment_method: {
+        statement_reference: 'some ref',
+        type: 'bank_transfer' as PaymentMethodType
+      },
+      beneficiary: {
+        type: 'external' as BeneficiaryType,
+        name: 'John Doe',
+        reference: 'Test Ref',
+        scheme_identifier: {
+          type: 'sort_code_account_number' as SchemeIdentifierType,
+          account_number: config.ACCOUNT_NUMBER,
+          sort_code: config.SORT_CODE
+        }
+      }
+    };
+  }
 }

--- a/src/controllers/paymentsV3.ts
+++ b/src/controllers/paymentsV3.ts
@@ -5,7 +5,7 @@ import AuthenticationClient from 'clients/authentication-client';
 import PaymentsClient from 'clients/paymentv3-client';
 import { HttpException } from 'middleware/errors';
 import config from 'config';
-import { BeneficiaryType, PaymentMethodType, SchemeIdentifierType } from 'models/v3/payments-api/create_payment';
+import { CreatePaymentRequest } from 'models/v3/payments-api/create_payment';
 
 export default class PaymentsV3Controller {
   private paymentClient = new PaymentsClient(new AuthenticationClient());
@@ -26,21 +26,21 @@ export default class PaymentsV3Controller {
     res.status(501).send();
   };
 
-  private buildPaymentRequest() {
+  private buildPaymentRequest(): CreatePaymentRequest {
     return {
       id: uuid(),
       amount_in_minor: 1,
       currency: 'GBP',
       payment_method: {
         statement_reference: 'some ref',
-        type: 'bank_transfer' as PaymentMethodType
+        type: 'bank_transfer'
       },
       beneficiary: {
-        type: 'external' as BeneficiaryType,
+        type: 'external',
         name: 'John Doe',
         reference: 'Test Ref',
         scheme_identifier: {
-          type: 'sort_code_account_number' as SchemeIdentifierType,
+          type: 'sort_code_account_number',
           account_number: config.ACCOUNT_NUMBER,
           sort_code: config.SORT_CODE
         }

--- a/src/models/v3/payments-api/create_payment.ts
+++ b/src/models/v3/payments-api/create_payment.ts
@@ -1,0 +1,45 @@
+/* eslint-disable camelcase */
+
+// Payment Method Details
+
+export type PaymentMethodType = 'bank_transfer';
+
+interface PaymentMethod {
+  type: PaymentMethodType;
+  statement_reference: string;
+}
+
+// Beneficiary Details
+
+export type BeneficiaryType = 'external';
+
+export type SchemeIdentifierType = 'sort_code_account_number';
+
+interface Beneficiary {
+  type: BeneficiaryType;
+  scheme_identifier: {
+    type: SchemeIdentifierType;
+    sort_code: string;
+    account_number: string;
+  };
+  name: string;
+  reference: string;
+}
+
+export interface CreatePaymentRequest {
+  id: string;
+  amount_in_minor: number;
+  currency: string;
+  payment_method: PaymentMethod;
+  beneficiary: Beneficiary;
+}
+
+export interface CreatePaymentRequestReponse {
+  id: string;
+  amount_in_minor: number;
+  currency: string;
+  payment_method: PaymentMethod;
+  beneficiary: Beneficiary;
+  status: string;
+  resource_token: string;
+}


### PR DESCRIPTION
Overview
--
- Implement Proxy to https://pay-api-specs.t7r.dev/#operation/create-payment

Notes: There is no real model separation between DTO / Model. This can be addressed once the API Spec has been finalised