### PR TITLE
Updating payment status API, so that it can be used by demo merchant …

### DIFF
--- a/src/clients/paymentv3-client.ts
+++ b/src/clients/paymentv3-client.ts
@@ -38,11 +38,6 @@ export default class PaymentClient {
     'content-type': 'application/json'
   });
 
-  private getResourceHeaders = (authorization: String) => ({
-    'authorization': authorization,
-    'content-type': 'application/json'
-  });
-
   /**
    * It creates a payment starting from a [CreatePaymentRequest](../models/v3/payments-api/create_payments.ts)
    *
@@ -85,8 +80,8 @@ export default class PaymentClient {
    *   - authorizationHeader: the authorization header that need to be sent to the Payments V3 Backend.
    * - returns: a payment status.
    */
-  getStatus = async (paymentId: string, authorizationHeader: string) => {
-    const headers = this.getResourceHeaders(authorizationHeader);
+  getStatus = async (paymentId: string) => {
+    const headers = await this.getHeaders();
 
     try {
       const { data } = await this.client.get<PaymentStatus>(`/payments/${paymentId}`, { headers });

--- a/src/controllers/paymentsV3.ts
+++ b/src/controllers/paymentsV3.ts
@@ -92,18 +92,11 @@ export default class PaymentsV3Controller {
   getPayment = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { id } = req.params;
-      const authorization = req.headers.authorization;
       if (!id) {
         throw new HttpException(400, 'Bad URL: the URL is missing the paymentId parameter in the URL path.');
       }
-      if (!authorization) {
-        throw new HttpException(
-          401,
-          'The call requires an Authorization header with the resource_token associated with the payment'
-        );
-      }
 
-      const response = await this.paymentClient.getStatus(id, authorization);
+      const response = await this.paymentClient.getStatus(id);
       res.status(200).send(response);
     } catch (e) {
       next(e instanceof HttpException ? e : new HttpException(500, 'Failed to retrieve the payment.'));

--- a/src/tests/v3_app.test.ts
+++ b/src/tests/v3_app.test.ts
@@ -20,13 +20,7 @@ describe('api v3', () => {
     let paymentsApi: Scope;
 
     beforeEach(() => {
-      paymentsApi = nock(config.PAYMENTS_V3_URI, {
-        reqheaders: {
-          'authorization':
-            'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJwZW5ueWRldi1lNTkzOGEiLCJqdGkiOiIzMTNlNTg2Zi1iYmViLTQ2NzktOTc0ZC1hMTMyYTM0ZGFlOTkiLCJuYmYiOjE2MzA1NjgzOTUsImV4cCI6MTYzMDU3MTk5NSwiaXNzIjoiaHR0cHM6Ly9hcGkudDdyLmRldiIsImF1ZCI6Imh0dHBzOi8vYXBpLnQ3ci5kZXYifQ.acqlq2lI1UbF-NyUGa57QU9P1faOYmjF-2BGpgfDnok',
-          'content-type': 'application/json'
-        }
-      });
+      paymentsApi = nock(config.PAYMENTS_V3_URI);
     });
 
     it('200 GET payment response from payments api is returned successfully through the proxy.', done => {
@@ -34,14 +28,7 @@ describe('api v3', () => {
 
       paymentsApi.get('/payments/313e586f-bbeb-4679-974d-a132a34dae99').times(1).reply(200, status);
       // Act & Assert
-      request
-        .get('/v3/payment/313e586f-bbeb-4679-974d-a132a34dae99')
-        .set(
-          'authorization',
-          'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJwZW5ueWRldi1lNTkzOGEiLCJqdGkiOiIzMTNlNTg2Zi1iYmViLTQ2NzktOTc0ZC1hMTMyYTM0ZGFlOTkiLCJuYmYiOjE2MzA1NjgzOTUsImV4cCI6MTYzMDU3MTk5NSwiaXNzIjoiaHR0cHM6Ly9hcGkudDdyLmRldiIsImF1ZCI6Imh0dHBzOi8vYXBpLnQ3ci5kZXYifQ.acqlq2lI1UbF-NyUGa57QU9P1faOYmjF-2BGpgfDnok'
-        )
-        .send()
-        .expect(200, mockStatusResponse, done);
+      request.get('/v3/payment/313e586f-bbeb-4679-974d-a132a34dae99').send().expect(200, mockStatusResponse, done);
     });
   });
 


### PR DESCRIPTION
…app on redirect back from bank when resource_token not available on the redirect URL.

When we get the redirect back from bank, we do not have the resource_token, so this is the api to be able to get payment status easily.
The same way as we create payment without authorization, we should be able to get payment status without it.