### PR TITLE
PUX-858: update hosted payments page subdomain

### DIFF
--- a/src/controllers/paymentsV3.ts
+++ b/src/controllers/paymentsV3.ts
@@ -73,7 +73,7 @@ export default class PaymentsV3Controller {
       // Ideally we should use DTOs / Domain Types but givent that the API spec is still work in progress, we keep the type transparent
       const response = await this.paymentClient.initiatePayment(request);
       res.status(200).send({
-        hpp_url: `https://checkout.t7r.dev/payments#payment_id=${response.id}&resource_token=${response.resource_token}&return_uri=${config.REDIRECT_URI}`,
+        hpp_url: `https://payment.t7r.dev/payments#payment_id=${response.id}&resource_token=${response.resource_token}&return_uri=${config.REDIRECT_URI}`,
         ...response
       });
     } catch (e) {

--- a/src/tests/v3_app.test.ts
+++ b/src/tests/v3_app.test.ts
@@ -58,7 +58,7 @@ describe('api v3', () => {
 
 const mockPaymentResponse = {
   hpp_url:
-    'https://checkout.t7r.dev/payments#payment_id=313e586f-bbeb-4679-974d-a132a34dae99&resource_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJwZW5ueWRldi1lNTkzOGEiLCJqdGkiOiIzMTNlNTg2Zi1iYmViLTQ2NzktOTc0ZC1hMTMyYTM0ZGFlOTkiLCJuYmYiOjE2MzA1NjgzOTUsImV4cCI6MTYzMDU3MTk5NSwiaXNzIjoiaHR0cHM6Ly9hcGkudDdyLmRldiIsImF1ZCI6Imh0dHBzOi8vYXBpLnQ3ci5kZXYifQ.acqlq2lI1UbF-NyUGa57QU9P1faOYmjF-2BGpgfDnok&return_uri=truelayer://payments_sample',
+    'https://payment.t7r.dev/payments#payment_id=313e586f-bbeb-4679-974d-a132a34dae99&resource_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJwZW5ueWRldi1lNTkzOGEiLCJqdGkiOiIzMTNlNTg2Zi1iYmViLTQ2NzktOTc0ZC1hMTMyYTM0ZGFlOTkiLCJuYmYiOjE2MzA1NjgzOTUsImV4cCI6MTYzMDU3MTk5NSwiaXNzIjoiaHR0cHM6Ly9hcGkudDdyLmRldiIsImF1ZCI6Imh0dHBzOi8vYXBpLnQ3ci5kZXYifQ.acqlq2lI1UbF-NyUGa57QU9P1faOYmjF-2BGpgfDnok&return_uri=truelayer://payments_sample',
   id: '313e586f-bbeb-4679-974d-a132a34dae99',
   amount_in_minor: 1,
   currency: 'GBP',


### PR DESCRIPTION
As part of https://truelayer.atlassian.net/jira/software/projects/PUX/boards/131?selectedIssue=PUX-858 the payments-ux team is updating the domain of hosted payments page.

Going from `checkout.*.*` to `payment.*.*`