### PR TITLE
[PUX-2721][Payments Quickstart] Include alpha providers by default 

### DIFF
--- a/src/controllers/paymentsV3.ts
+++ b/src/controllers/paymentsV3.ts
@@ -4,7 +4,7 @@ import AuthenticationClient from 'clients/authentication-client';
 import PaymentsClient from 'clients/paymentv3-client';
 import { HttpException } from 'middleware/errors';
 import config from 'config';
-import { AccountIdentifierType, CreatePaymentRequest } from 'models/v3/payments-api/create_payment';
+import { AccountIdentifierType, CreatePaymentRequest, ProviderFilter } from 'models/v3/payments-api/create_payment';
 
 /**
  * Controller for the PaymentsV3 API.
@@ -136,6 +136,15 @@ export default class PaymentsV3Controller {
   };
 
   private buildPaymentRequest(currency?: 'EUR'): CreatePaymentRequest {
+    // Include private_beta providers by default 
+    const filter: ProviderFilter = {
+      release_channel: "alpha",
+      countries: null,
+      customer_segments: null,
+      provider_ids: null,
+      excludes: null
+    };
+
     return currency
       ? {
           ...this.basePayment,
@@ -146,11 +155,11 @@ export default class PaymentsV3Controller {
               ? {
                   type: 'preselected',
                   provider_id: config.PROVIDER_ID_PRESELECTED,
-                  scheme_id: 'sepa_credit_transfer'
+                  scheme_id: 'sepa_credit_transfer',
                 }
               : {
                   type: 'user_selected',
-                  filter: null
+                  filter
                 },
             beneficiary: {
               type: 'external_account',
@@ -170,7 +179,7 @@ export default class PaymentsV3Controller {
             type: 'bank_transfer',
             provider_selection: {
               type: 'user_selected',
-              filter: null
+              filter
             },
             beneficiary: {
               type: 'external_account',

--- a/src/controllers/paymentsV3.ts
+++ b/src/controllers/paymentsV3.ts
@@ -136,7 +136,8 @@ export default class PaymentsV3Controller {
   };
 
   private buildPaymentRequest(currency?: 'EUR'): CreatePaymentRequest {
-    // Include private_beta providers by default
+    // Include all providers by default,
+    // this is particulary useful when testing on Mobile to test against embedded flow mock banks (xs2a-volksbanken-de-sandbox)
     const filter: ProviderFilter = {
       release_channel: 'alpha',
       countries: null,

--- a/src/controllers/paymentsV3.ts
+++ b/src/controllers/paymentsV3.ts
@@ -137,7 +137,7 @@ export default class PaymentsV3Controller {
 
   private buildPaymentRequest(currency?: 'EUR'): CreatePaymentRequest {
     // Include all providers by default,
-    // this is particulary useful when testing on Mobile to test against embedded flow mock banks (xs2a-volksbanken-de-sandbox)
+    // this is particulary useful when testing against embedded flow mock banks on Mobile (xs2a-volksbanken-de-sandbox)
     const filter: ProviderFilter = {
       release_channel: 'alpha',
       countries: null,

--- a/src/controllers/paymentsV3.ts
+++ b/src/controllers/paymentsV3.ts
@@ -136,9 +136,9 @@ export default class PaymentsV3Controller {
   };
 
   private buildPaymentRequest(currency?: 'EUR'): CreatePaymentRequest {
-    // Include private_beta providers by default 
+    // Include private_beta providers by default
     const filter: ProviderFilter = {
-      release_channel: "alpha",
+      release_channel: 'alpha',
       countries: null,
       customer_segments: null,
       provider_ids: null,
@@ -155,7 +155,7 @@ export default class PaymentsV3Controller {
               ? {
                   type: 'preselected',
                   provider_id: config.PROVIDER_ID_PRESELECTED,
-                  scheme_id: 'sepa_credit_transfer',
+                  scheme_id: 'sepa_credit_transfer'
                 }
               : {
                   type: 'user_selected',


### PR DESCRIPTION
Overview
--
- Create payments with `alpha` providers to include more interesting banks such as `Volksbanken Raiffeisenbanken Sandbox` by default